### PR TITLE
Fix null texture keys during item processing

### DIFF
--- a/shared/src/main/java/org/geysermc/hydraulic/item/BowPackModule.java
+++ b/shared/src/main/java/org/geysermc/hydraulic/item/BowPackModule.java
@@ -100,7 +100,13 @@ public class BowPackModule extends TexturePackModule<BowPackModule> {
             }
 
             ModelTexture layer0 = layers.getFirst();
-            String defaultOutputLoc = getOutputFromModel(context, layer0.key()).replace(".png", "");
+            Key layer0Key = layer0.key();
+            if (layer0Key == null) {
+                context.logger().warn("Bow {} has no layer0 texture key, skipping", bowLocation);
+                continue;
+            }
+
+            String defaultOutputLoc = getOutputFromModel(context, layer0Key).replace(".png", "");
 
             textures.put("default", defaultOutputLoc);
 
@@ -118,7 +124,13 @@ public class BowPackModule extends TexturePackModule<BowPackModule> {
                 }
 
                 ModelTexture pullingLayer0 = pullingLayers.getFirst();
-                String outputLoc = getOutputFromModel(context, pullingLayer0.key()).replace(".png", "");
+                Key pullingKey = pullingLayer0.key();
+                if (pullingKey == null) {
+                    context.logger().warn("Bow pulling model {} has no texture key, skipping", override.model());
+                    continue;
+                }
+
+                String outputLoc = getOutputFromModel(context, pullingKey).replace(".png", "");
 
                 Map<String, Float> predicate = new HashMap<>();
                 for (ItemPredicate itemPredicate : override.predicate()) {

--- a/shared/src/main/java/org/geysermc/hydraulic/item/ItemPackModule.java
+++ b/shared/src/main/java/org/geysermc/hydraulic/item/ItemPackModule.java
@@ -159,7 +159,14 @@ public class ItemPackModule extends TexturePackModule<ItemPackModule> {
             }
 
             ModelTexture layer0 = layers.getFirst();
-            String outputLoc = getOutputFromModel(context, layer0.key()); // TODO: sort this out, layer0.key() can be null, but the method we use doesn't want that
+
+            Key textureKey = layer0.key();
+            if (textureKey == null) {
+                context.logger().warn("Item {} has no texture key for layer0, skipping", itemLocation);
+                continue;
+            }
+
+            String outputLoc = getOutputFromModel(context, textureKey);
             bedrockPack.addItemTexture(itemLocation.toString(), outputLoc.replace(".png", ""));
         }
     }


### PR DESCRIPTION
## Summary
- handle missing texture key values when building pack textures for items and bows

## Testing
- `./gradlew build -x test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fa1ff3ef08332baca773f113e569e